### PR TITLE
feat(cli): support pattern fallback via git config (ref #3)

### DIFF
--- a/src/git/gitConfig.test.ts
+++ b/src/git/gitConfig.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock execa
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from "execa";
+import { getGitConfig } from "./gitConfig.js";
+
+const execaMock = execa as unknown as ReturnType<typeof vi.fn>;
+
+describe("getGitConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns trimmed value when git config succeeds", async () => {
+    execaMock.mockResolvedValueOnce({ stdout: "  {type}/{title}-{id}  " });
+
+    const result = await getGitConfig("new-branch.pattern");
+
+    expect(execaMock).toHaveBeenCalledWith("git", ["config", "--get", "new-branch.pattern"]);
+
+    expect(result).toBe("{type}/{title}-{id}");
+  });
+
+  it("returns undefined when stdout is empty", async () => {
+    execaMock.mockResolvedValueOnce({ stdout: "   " });
+
+    const result = await getGitConfig("new-branch.pattern");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when git config throws", async () => {
+    execaMock.mockRejectedValueOnce(new Error("not found"));
+
+    const result = await getGitConfig("new-branch.pattern");
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/git/gitConfig.ts
+++ b/src/git/gitConfig.ts
@@ -1,0 +1,11 @@
+import { execa } from "execa";
+
+export async function getGitConfig(key: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execa("git", ["config", "--get", key]);
+    const value = stdout.trim();
+    return value.length ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
- Add getGitConfig helper to read `new-branch.pattern`
- Allow branch pattern to be resolved from git config
- Respect precedence: CLI > package.json > git config
- Add unit tests for gitConfig
- Update CLI tests to cover precedence behavior