### PR TITLE
feat(runtime): add date-based built-in variables and git config pattern support (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,19 @@ Example:
 
 ## Built-in Variables
 
+### Core Variables
+
 - `type`
 - `title`
 - `id`
+
+### Date Built-ins (derived from local system time)
+
+- `year` → YYYY
+- `month` → MM (zero padded)
+- `day` → DD (zero padded)
+- `date` → YYYY-MM-DD
+- `dateCompact` → YYYYMMDD
 
 ---
 
@@ -150,11 +160,36 @@ You can define a default pattern in `package.json`:
 }
 ```
 
-Resolution order:
+### Git Configuration
+
+You can also define a default pattern using Git config:
+
+```bash
+git config --local new-branch.pattern "{type}/{title:slugify}-{id}"
+```
+
+Or globally:
+
+```bash
+git config --global new-branch.pattern "{type}/{title:slugify}-{id}"
+```
+
+To remove the pattern from Git config:
+
+```bash
+# Remove from local repository
+git config --unset --local new-branch.pattern
+
+# Remove from global config
+git config --unset --global new-branch.pattern
+```
+
+When using Git config, the resolution order becomes:
 
 1. CLI flags
 2. `package.json` configuration
-3. Interactive prompt (if enabled)
+3. Git config (`new-branch.pattern`)
+4. Interactive prompt (if enabled)
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { parsePattern } from "@/pattern/parsePattern.js";
 import { defaultTransforms } from "@/pattern/transforms/index.js";
 import { renderPattern } from "@/pattern/transforms/renderPattern.js";
 import { resolveMissingValues } from "@/runtime/resolveMissingValues.js";
+import { getBuiltinValues } from "@/runtime/builtins.js";
 import { loadProjectConfig } from "./config/loadProjectConfig.js";
 import { getGitConfig } from "@/git/gitConfig.js";
 import type { RenderValues } from "@/pattern/transforms/renderPattern.js";
@@ -104,7 +105,12 @@ export async function run(): Promise<void> {
   const astRes = safe(() => parsePattern(patternRes.value));
   if (!isOk(astRes)) fail("Invalid pattern.", astRes.error);
 
-  const initialValues = toInitialValues(args);
+  const builtinValues = getBuiltinValues();
+
+  const initialValues = {
+    ...builtinValues,
+    ...toInitialValues(args),
+  };
 
   const valuesRes = await safeAsync(() =>
     resolveMissingValues(astRes.value, initialValues, {

--- a/src/runtime/builtins.test.ts
+++ b/src/runtime/builtins.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { getBuiltinValues } from "./builtins.js";
+
+describe("getBuiltinValues", () => {
+  it("returns correct padded date values", () => {
+    const fake = new Date("2026-02-09T10:00:00Z");
+
+    const result = getBuiltinValues(fake);
+
+    expect(result.year).toBe("2026");
+    expect(result.month).toBe("02");
+    expect(result.day).toBe("09");
+    expect(result.date).toBe("2026-02-09");
+    expect(result.dateCompact).toBe("20260209");
+  });
+});

--- a/src/runtime/builtins.ts
+++ b/src/runtime/builtins.ts
@@ -1,0 +1,55 @@
+/**
+ * Represents a map of built-in runtime values available
+ * during pattern rendering.
+ *
+ * All values are strings to keep the rendering pipeline
+ * strictly string-based and simple.
+ */
+export type BuiltinValues = Record<string, string>;
+
+/**
+ * Pads a number with a leading zero when necessary.
+ *
+ * @param n - Number to pad.
+ * @returns A zero-padded string (e.g., 2 → "02").
+ */
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/**
+ * Returns built-in date-based variables derived from
+ * the local system time.
+ *
+ * This function is intentionally synchronous and pure.
+ * The optional `now` parameter allows deterministic testing.
+ *
+ * Provided variables:
+ *
+ * - `year`        → YYYY
+ * - `month`       → MM (zero padded)
+ * - `day`         → DD (zero padded)
+ * - `date`        → YYYY-MM-DD
+ * - `dateCompact` → YYYYMMDD
+ *
+ * @param now - Optional Date instance used to generate values.
+ *              Defaults to the current system date/time.
+ * @returns An object containing built-in date variables.
+ *
+ * @example
+ * const builtins = getBuiltinValues(new Date("2026-02-19"));
+ * builtins.date; // "2026-02-19"
+ */
+export function getBuiltinValues(now: Date = new Date()): BuiltinValues {
+  const year = String(now.getFullYear());
+  const month = pad(now.getMonth() + 1);
+  const day = pad(now.getDate());
+
+  return {
+    year,
+    month,
+    day,
+    date: `${year}-${month}-${day}`,
+    dateCompact: `${year}${month}${day}`,
+  };
+}


### PR DESCRIPTION

- Introduce runtime built-ins: year, month, day, date, dateCompact
- Inject built-in values into CLI before resolving missing values
- Add support for loading default pattern from git config (new-branch.pattern)
- Update README with new built-in variables and git configuration instructions
- Add unit tests for built-in date variables
