### PR TITLE
feat(git): add git built-in variables with lazy resolution and CLI integration (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,35 @@ Example:
 - `date` → YYYY-MM-DD
 - `dateCompact` → YYYYMMDD
 
+### Git Built-ins (derived from current Git repository)
+
+- `currentBranch` → Current Git branch name (e.g. `main`, `feature/PROJ-123`)
+- `shortSha` → Short SHA of `HEAD` (e.g. `a1b2c3d`)
+- `repoName` → Repository directory name
+- `userName` → Git user name (`git config user.name`)
+- `lastTag` → Most recent Git tag (`git describe --tags --abbrev=0`)
+
+> Note:
+>
+> - Git built-ins are resolved lazily and only when referenced in the pattern.
+> - They are never prompted interactively.
+> - When unavailable (e.g. outside a Git repository), they resolve to an empty string.
+
+#### Example with Git built-ins
+
+```bash
+new-branch \
+  --pattern "{currentBranch}-{shortSha}-{type}-{title:slugify}" \
+  --type feat \
+  --title "Improve logging"
+```
+
+Example output:
+
+```
+main-a1b2c3d-feat-improve-logging
+```
+
 ---
 
 ## Built-in Transforms

--- a/src/git/gitBuiltins.test.ts
+++ b/src/git/gitBuiltins.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockedFunction } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}));
+
+vi.mock("@/git/gitConfig.js", () => ({
+  getGitConfig: vi.fn(),
+}));
+
+import { execa } from "execa";
+import { getGitConfig } from "./gitConfig.js";
+
+import {
+  getGitBuiltins,
+  patternNeedsGitBuiltins,
+  extractGitBuiltinKeysFromPattern,
+} from "./gitBuiltins.js";
+
+function setEnv(user?: string, username?: string) {
+  if (user === undefined) delete process.env.USER;
+  else process.env.USER = user;
+
+  if (username === undefined) delete process.env.USERNAME;
+  else process.env.USERNAME = username;
+}
+
+describe("gitBuiltins", () => {
+  // Define minimal types to avoid using `any` while keeping the mocks flexible.
+  type ExecaReturn = { stdout: string };
+  type ExecaFn = (...args: unknown[]) => Promise<ExecaReturn>;
+  type GetGitConfigFn = (...args: unknown[]) => Promise<string | undefined>;
+
+  // Cast to unknown first to avoid incompatibilities between execa's complex
+  // function types and Vitest's MockedFunction helper.
+  const execaMock = execa as unknown as MockedFunction<ExecaFn>;
+  const getGitConfigMock = getGitConfig as unknown as MockedFunction<GetGitConfigFn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setEnv(undefined, undefined);
+  });
+
+  afterEach(() => {
+    setEnv(undefined, undefined);
+  });
+
+  it("patternNeedsGitBuiltins(): true when pattern contains any git key", () => {
+    expect(patternNeedsGitBuiltins("feat/{shortSha}/x")).toBe(true);
+    expect(patternNeedsGitBuiltins("feat/{userName}/x")).toBe(true);
+  });
+
+  it("patternNeedsGitBuiltins(): false when pattern contains no git keys", () => {
+    expect(patternNeedsGitBuiltins("feat/{slug}/x")).toBe(false);
+    expect(patternNeedsGitBuiltins("hello world")).toBe(false);
+  });
+
+  it("extractGitBuiltinKeysFromPattern(): returns only keys present", () => {
+    const keys = extractGitBuiltinKeysFromPattern("feat/{shortSha}/{repoName}/{currentBranch}");
+    expect(keys.sort()).toEqual(["currentBranch", "repoName", "shortSha"].sort());
+  });
+
+  it("getGitBuiltins(keys): resolves only requested keys", async () => {
+    execaMock.mockImplementation(async (...argv: unknown[]) => {
+      const args = argv[1] as readonly string[];
+      const joined = args.join(" ");
+      if (joined === "rev-parse --short HEAD") return { stdout: "abc123\n" } as ExecaReturn;
+      throw new Error("unexpected git call: " + joined);
+    });
+
+    const result = await getGitBuiltins(["shortSha"]);
+    expect(result).toEqual({ shortSha: "abc123" });
+
+    // ensure only that git command ran
+    expect(execaMock).toHaveBeenCalledTimes(1);
+    expect(execaMock).toHaveBeenCalledWith("git", ["rev-parse", "--short", "HEAD"]);
+  });
+
+  it("getGitBuiltins(keys): de-duplicates keys (uniqueKeys behavior)", async () => {
+    execaMock.mockResolvedValue({ stdout: "abc123\n" } as ExecaReturn);
+
+    const result = await getGitBuiltins(["shortSha", "shortSha"]);
+    expect(result).toEqual({ shortSha: "abc123" });
+    expect(execaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shortSha: returns undefined on git failure", async () => {
+    execaMock.mockRejectedValue(new Error("git error"));
+
+    const result = await getGitBuiltins(["shortSha"]);
+    expect(result).toEqual({ shortSha: undefined });
+  });
+
+  it("currentBranch: returns undefined when git returns HEAD (detached)", async () => {
+    execaMock.mockImplementation(async (...argv: unknown[]) => {
+      const args = argv[1] as readonly string[];
+      if (args.join(" ") === "rev-parse --abbrev-ref HEAD")
+        return { stdout: "HEAD\n" } as ExecaReturn;
+      throw new Error("unexpected");
+    });
+
+    const result = await getGitBuiltins(["currentBranch"]);
+    expect(result).toEqual({ currentBranch: undefined });
+  });
+
+  it("currentBranch: returns branch name when not HEAD", async () => {
+    execaMock.mockResolvedValue({ stdout: "main\n" } as ExecaReturn);
+
+    const result = await getGitBuiltins(["currentBranch"]);
+    expect(result).toEqual({ currentBranch: "main" });
+  });
+
+  it("repoName: derives from repo root path (unix)", async () => {
+    execaMock.mockImplementation(async (...argv: unknown[]) => {
+      const args = argv[1] as readonly string[];
+      if (args.join(" ") === "rev-parse --show-toplevel") {
+        return { stdout: "/home/teles/dev/new-branch\n" } as ExecaReturn;
+      }
+      throw new Error("unexpected");
+    });
+
+    const result = await getGitBuiltins(["repoName"]);
+    expect(result).toEqual({ repoName: "new-branch" });
+  });
+
+  it("repoName: derives from repo root path (windows)", async () => {
+    execaMock.mockImplementation(async (...argv: unknown[]) => {
+      const args = argv[1] as readonly string[];
+      if (args.join(" ") === "rev-parse --show-toplevel") {
+        return { stdout: "C:\\Users\\teles\\dev\\new-branch\n" } as ExecaReturn;
+      }
+      throw new Error("unexpected");
+    });
+
+    const result = await getGitBuiltins(["repoName"]);
+    expect(result).toEqual({ repoName: "new-branch" });
+  });
+
+  it("lastTag: returns latest tag", async () => {
+    execaMock.mockResolvedValue({ stdout: "v1.2.3\n" } as ExecaReturn);
+
+    const result = await getGitBuiltins(["lastTag"]);
+    expect(result).toEqual({ lastTag: "v1.2.3" });
+  });
+
+  it("userName: uses git config user.name when available", async () => {
+    getGitConfigMock.mockResolvedValue("José");
+
+    const result = await getGitBuiltins(["userName"]);
+    expect(result).toEqual({ userName: "José" });
+  });
+
+  it("userName: falls back to env USER / USERNAME when git config is undefined", async () => {
+    getGitConfigMock.mockResolvedValue(undefined);
+    setEnv("teles", undefined);
+
+    const result = await getGitBuiltins(["userName"]);
+    expect(result).toEqual({ userName: "teles" });
+  });
+
+  it("userName: returns undefined when git config is undefined and no env", async () => {
+    getGitConfigMock.mockResolvedValue(undefined);
+    setEnv(undefined, undefined);
+
+    const result = await getGitBuiltins(["userName"]);
+    expect(result).toEqual({ userName: undefined });
+  });
+
+  it("getGitBuiltins(): resolves all keys when keys omitted", async () => {
+    getGitConfigMock.mockResolvedValue("José");
+
+    execaMock.mockImplementation(async (...argv: unknown[]) => {
+      const args = argv[1] as readonly string[];
+      const joined = args.join(" ");
+      if (joined === "rev-parse --short HEAD") return { stdout: "abc123\n" } as ExecaReturn;
+      if (joined === "rev-parse --abbrev-ref HEAD") return { stdout: "main\n" } as ExecaReturn;
+      if (joined === "rev-parse --show-toplevel")
+        return { stdout: "/x/y/new-branch\n" } as ExecaReturn;
+      if (joined === "describe --tags --abbrev=0") return { stdout: "v0.3.1\n" } as ExecaReturn;
+      throw new Error("unexpected: " + joined);
+    });
+
+    const result = await getGitBuiltins();
+    expect(result).toEqual({
+      shortSha: "abc123",
+      currentBranch: "main",
+      userName: "José",
+      repoName: "new-branch",
+      lastTag: "v0.3.1",
+    });
+  });
+});

--- a/src/git/gitBuiltins.ts
+++ b/src/git/gitBuiltins.ts
@@ -1,0 +1,106 @@
+import { execa } from "execa";
+import { getGitConfig } from "@/git/gitConfig.js";
+
+export type GitBuiltins = {
+  shortSha?: string;
+  currentBranch?: string;
+  userName?: string;
+  repoName?: string;
+  lastTag?: string;
+};
+
+export type GitBuiltinKey = keyof GitBuiltins;
+
+export const GIT_BUILTIN_KEYS: GitBuiltinKey[] = [
+  "shortSha",
+  "currentBranch",
+  "userName",
+  "repoName",
+  "lastTag",
+];
+
+function uniqueKeys(keys: GitBuiltinKey[]): GitBuiltinKey[] {
+  return Array.from(new Set(keys));
+}
+
+function pickAllKeysIfUndefined(keys?: GitBuiltinKey[]): GitBuiltinKey[] {
+  return keys?.length ? uniqueKeys(keys) : GIT_BUILTIN_KEYS;
+}
+
+async function safeExec(args: string[]): Promise<string | undefined> {
+  try {
+    const { stdout } = await execa("git", args);
+    const value = stdout.trim();
+    return value.length ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function deriveRepoName(repoRoot: string): string | undefined {
+  const parts = repoRoot.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : undefined;
+}
+
+const RESOLVERS: Record<GitBuiltinKey, () => Promise<string | undefined>> = {
+  shortSha: () => safeExec(["rev-parse", "--short", "HEAD"]),
+
+  currentBranch: async () => {
+    const value = await safeExec(["rev-parse", "--abbrev-ref", "HEAD"]);
+    return value === "HEAD" ? undefined : value;
+  },
+
+  repoName: async () => {
+    const repoRoot = await safeExec(["rev-parse", "--show-toplevel"]);
+    return repoRoot ? deriveRepoName(repoRoot) : undefined;
+  },
+
+  lastTag: () => safeExec(["describe", "--tags", "--abbrev=0"]),
+
+  userName: async () => {
+    const value = await getGitConfig("user.name");
+    return value ?? process.env.USER ?? process.env.USERNAME ?? undefined;
+  },
+};
+
+async function resolveGitBuiltins(keys?: GitBuiltinKey[]): Promise<GitBuiltins> {
+  const wanted = pickAllKeysIfUndefined(keys);
+
+  const entries = await Promise.all(
+    wanted.map(async (key) => {
+      const value = await RESOLVERS[key]();
+      return [key, value] as const;
+    }),
+  );
+
+  return entries.reduce<GitBuiltins>((acc, [key, value]) => {
+    acc[key] = value;
+    return acc;
+  }, {});
+}
+
+/**
+ * Resolves git-based built-in variables.
+ *
+ * - If `keys` is omitted, resolves all supported git builtins.
+ * - If `keys` is provided, resolves only those keys.
+ */
+export async function getGitBuiltins(keys?: GitBuiltinKey[]): Promise<GitBuiltins> {
+  return resolveGitBuiltins(keys);
+}
+
+/**
+ * Returns true if the pattern contains at least one git builtin key.
+ * (Call this before `getGitBuiltins()` if you want to avoid running git at all.)
+ */
+export function patternNeedsGitBuiltins(pattern: string): boolean {
+  return GIT_BUILTIN_KEYS.some((key) => pattern.includes(key));
+}
+
+/**
+ * Extracts which git builtin keys are present in the pattern.
+ * (Use the returned keys to resolve only what you need.)
+ */
+export function extractGitBuiltinKeysFromPattern(pattern: string): GitBuiltinKey[] {
+  return GIT_BUILTIN_KEYS.filter((key) => pattern.includes(key));
+}


### PR DESCRIPTION
Adds support for Git-derived built-in variables that can be used inside branch patterns:

- shortSha
- currentBranch
- repoName
- userName
- lastTag

Key changes:

- Introduces src/git/gitBuiltins.ts with a centralized resolver map that defines how each Git built-in is resolved.
- Built-ins are resolved lazily: Git commands are executed only if the pattern references at least one Git key.
- Only the required Git keys are resolved per execution.
- Git built-ins are never prompted interactively.
- When Git data is unavailable (e.g. outside a repo), values resolve to undefined and are rendered as empty strings.

CLI integration:

- Detects Git keys via patternNeedsGitBuiltins().
- Extracts only required keys using extractGitBuiltinKeysFromPattern().
- Merges Git built-ins with runtime (date) built-ins and CLI-provided values.
- Ensures resolveMissingValues does not prompt for Git-derived variables.

Tests:

- Adds comprehensive unit tests for gitBuiltins:
  - success and failure cases
  - detached HEAD behavior
  - Windows and Unix repo path handling
  - env fallback for userName
  - resolving specific keys only
- Updates cli.test.ts to mock Git built-in resolution and validate:
  - lazy resolution behavior
  - correct merging of values
  - no Git resolution when pattern does not reference Git keys

Docs:

- Updates README with a new Git Built-ins section.
- Documents behavior, resolution strategy, and example usage.

This enables dynamic branch names that include repository metadata without impacting performance or interactive UX.