### PR TITLE
feat(init): add interactive init wizard (new-branch init)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,22 @@ npm install -g new-branch
 
 ## Quick Start
 
+Bootstrap a `.newbranchrc.json` config interactively:
+
+```bash
+new-branch init
+```
+
+Or accept all defaults in one shot:
+
+```bash
+new-branch init --yes
+```
+
+Then generate branch names:
+
 ```bash
 new-branch \
-  --pattern "{type}/{title:slugify;max:25}-{id}" \
   --type feat \
   --title "Add login page" \
   --id PROJ-123 \
@@ -42,7 +55,7 @@ new-branch \
 ✅ Branch created and switched to: feat/add-login-page-PROJ-123
 ```
 
-Save your pattern so you don't have to type it every time:
+You can also pass a pattern inline:
 
 ```json
 {
@@ -58,6 +71,7 @@ Save your pattern so you don't have to type it every time:
 
 - **Pattern language** — declarative syntax with variables, transforms, and arguments
 - **16 built-in transforms** — `slugify`, `kebab`, `camel`, `max`, `replace`, `stripAccents`, and more
+- **Interactive init wizard** — `new-branch init` bootstraps your config with live preview
 - **Flexible config** — `.newbranchrc.json`, `package.json`, or `git config`
 - **Pattern aliases** — define named patterns and switch with `--use feature`
 - **Interactive mode** — prompts for missing values, disable with `--no-prompt`
@@ -69,6 +83,7 @@ Save your pattern so you don't have to type it every time:
 | Section                                                                     | Description                          |
 | --------------------------------------------------------------------------- | ------------------------------------ |
 | [Getting Started](https://teles.github.io/new-branch/guide/getting-started) | Installation and first branch        |
+| [Init Wizard](https://teles.github.io/new-branch/guide/init)                | Bootstrap config interactively       |
 | [Patterns](https://teles.github.io/new-branch/guide/patterns)               | Pattern language syntax and examples |
 | [Transforms](https://teles.github.io/new-branch/guide/transforms)           | All 16 transforms with I/O tables    |
 | [Configuration](https://teles.github.io/new-branch/guide/configuration)     | Config sources and precedence        |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         {
           text: "Features",
           items: [
+            { text: "Init Wizard", link: "/guide/init" },
             { text: "Interactive Mode", link: "/guide/interactive-mode" },
             { text: "Didactic Modes", link: "/guide/didactic-modes" },
           ],

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -30,7 +30,7 @@ new-branch --pattern "{type}/{title:slugify}-{id}" --type feat
 
 ### `.newbranchrc.json`
 
-A JSON file at the root of your repository:
+A JSON file at the root of your repository. You can create one interactively with [`new-branch init`](/guide/init), or write it manually:
 
 ```json
 {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -93,9 +93,27 @@ new-branch --pattern "{type}/{title:slugify}-{id}" --no-prompt
 # → Fails with an error listing missing values
 ```
 
+## Bootstrap Your Config
+
+Instead of creating a config file manually, use the **init wizard**:
+
+```bash
+new-branch init
+```
+
+The wizard walks you through selecting variables, transforms, branch types, and pattern aliases — with a **live preview** at each step. It writes a `.newbranchrc.json` file when you're done.
+
+For CI or quick setup, accept all defaults:
+
+```bash
+new-branch init --yes
+```
+
+Learn more in the [Init Wizard](/guide/init) guide.
+
 ## Save Your Pattern
 
-Instead of typing `--pattern` every time, save it in your project config:
+You can also create a config file manually:
 
 ::: code-group
 
@@ -132,6 +150,7 @@ new-branch --type feat --title "Add login page" --id PROJ-123
 
 ## What's Next?
 
+- Bootstrap your config with the [Init Wizard](/guide/init)
 - Learn the [Pattern Language](/guide/patterns) in depth
 - See all available [Transforms](/guide/transforms)
 - Configure [Pattern Aliases](/guide/pattern-aliases) for different workflows

--- a/docs/guide/init.md
+++ b/docs/guide/init.md
@@ -1,0 +1,147 @@
+# Init Wizard
+
+The `new-branch init` command creates a `.newbranchrc.json` configuration file through an interactive wizard with **live preview**.
+
+## Quick Start
+
+```bash
+new-branch init
+```
+
+Or accept all defaults without prompting:
+
+```bash
+new-branch init --yes
+```
+
+::: tip
+The `--yes` (or `-y`) flag is useful for CI/CD pipelines or when you just want a sensible starting point to customize later.
+:::
+
+## What the Wizard Does
+
+The init wizard walks you through each configuration decision in order:
+
+### 1. Select Variables
+
+Choose which variables to include in your branch name pattern:
+
+```
+? Which variables do you want in your branch name?
+  ◉ type — Branch type (feat, fix, chore...)
+  ◉ title — Task or feature title
+  ◉ id — Task identifier (PROJ-123)
+  ◯ date — Current date (YYYY-MM-DD)
+  ◯ userName — Git user name
+  ...
+```
+
+### 2. Choose Separators
+
+Pick separators between each variable pair:
+
+```
+? Separator between {type} and {title}:
+  ● / (slash)
+  ○ - (dash)
+  ○ _ (underscore)
+  ○ . (dot)
+```
+
+### 3. Apply Transforms
+
+Select transforms for text variables like `title`:
+
+```
+? Apply transforms to {title}?
+  ● slugify — URL-safe slug
+  ○ slugify + max — Slug with length limit
+  ○ kebab — kebab-case
+  ○ snake — snake_case
+  ○ none — Leave as-is
+```
+
+### 4. Live Preview
+
+After building the pattern, the wizard shows a preview with realistic mock values:
+
+```
+🔍 Preview: feat/add-login-page-PROJ-123
+```
+
+### 5. Define Branch Types (Optional)
+
+Optionally define allowed branch types:
+
+```
+? Define branch types? Yes
+? Use common defaults (feat, fix, chore)? Yes
+? Add more types? No
+? Set a default type? feat
+```
+
+### 6. Define Pattern Aliases (Optional)
+
+Optionally define named pattern aliases for `--use`:
+
+```
+? Define pattern aliases for --use? Yes
+? Alias name: hotfix
+? Pattern for "hotfix": hotfix/{title:slugify}-{id}
+   🔍 Preview: hotfix/add-login-page-PROJ-123
+? Add another alias? No
+```
+
+### 7. Write Config
+
+The wizard displays the final configuration and asks for confirmation:
+
+```
+📄 Configuration to write:
+
+{
+  "pattern": "{type}/{title:slugify}-{id}",
+  "types": [
+    { "value": "feat", "label": "Feature" },
+    { "value": "fix", "label": "Bug Fix" },
+    { "value": "chore", "label": "Chore" }
+  ],
+  "defaultType": "feat"
+}
+
+? Write to .newbranchrc.json? Yes
+✅ Written to .newbranchrc.json
+```
+
+## Default Config (`--yes`)
+
+When using `--yes`, the wizard writes this configuration without any prompts:
+
+```json
+{
+  "pattern": "{type}/{title:slugify}-{id}",
+  "types": [
+    { "value": "feat", "label": "Feature" },
+    { "value": "fix", "label": "Bug Fix" },
+    { "value": "chore", "label": "Chore" }
+  ],
+  "defaultType": "feat"
+}
+```
+
+## Overwriting Existing Config
+
+If a `.newbranchrc.json` already exists:
+
+- **Interactive mode**: the wizard asks whether to overwrite or abort.
+- **`--yes` mode**: the file is overwritten with a warning message.
+
+## After Init
+
+Once your config is in place, you can generate branches without specifying a pattern:
+
+```bash
+new-branch --type feat --title "Add login page" --id PROJ-123
+```
+
+See [Configuration](/guide/configuration) for all config options and precedence rules.

--- a/docs/guide/init.md
+++ b/docs/guide/init.md
@@ -1,6 +1,6 @@
 # Init Wizard
 
-The `new-branch init` command creates a `.newbranchrc.json` configuration file through an interactive wizard with **live preview**.
+The `new-branch init` command creates a `new-branch` configuration through an interactive wizard with **live preview**. You can save to `.newbranchrc.json`, `package.json`, or `git config`.
 
 ## Quick Start
 
@@ -22,7 +22,22 @@ The `--yes` (or `-y`) flag is useful for CI/CD pipelines or when you just want a
 
 The init wizard walks you through each configuration decision in order:
 
-### 1. Select Variables
+### 1. Choose Config Target
+
+First, select where to save your configuration:
+
+```
+? Where do you want to save the configuration?
+  ● .newbranchrc.json — Dedicated config file
+  ○ package.json — Under the "new-branch" key
+  ○ git config — Local repo git config
+```
+
+::: info
+All three targets are fully supported by `new-branch` at runtime. See [Configuration](/guide/configuration) for precedence rules.
+:::
+
+### 2. Select Variables
 
 Choose which variables to include in your branch name pattern:
 
@@ -36,7 +51,7 @@ Choose which variables to include in your branch name pattern:
   ...
 ```
 
-### 2. Choose Separators
+### 3. Choose Separators
 
 Pick separators between each variable pair:
 
@@ -48,7 +63,7 @@ Pick separators between each variable pair:
   ○ . (dot)
 ```
 
-### 3. Apply Transforms
+### 4. Apply Transforms
 
 Select transforms for text variables like `title`:
 
@@ -61,7 +76,7 @@ Select transforms for text variables like `title`:
   ○ none — Leave as-is
 ```
 
-### 4. Live Preview
+### 5. Live Preview
 
 After building the pattern, the wizard shows a preview with realistic mock values:
 
@@ -69,7 +84,7 @@ After building the pattern, the wizard shows a preview with realistic mock value
 🔍 Preview: feat/add-login-page-PROJ-123
 ```
 
-### 5. Define Branch Types (Optional)
+### 6. Define Branch Types (Optional)
 
 Optionally define allowed branch types:
 
@@ -80,7 +95,7 @@ Optionally define allowed branch types:
 ? Set a default type? feat
 ```
 
-### 6. Define Pattern Aliases (Optional)
+### 7. Define Pattern Aliases (Optional)
 
 Optionally define named pattern aliases for `--use`:
 
@@ -92,7 +107,7 @@ Optionally define named pattern aliases for `--use`:
 ? Add another alias? No
 ```
 
-### 7. Write Config
+### 8. Write Config
 
 The wizard displays the final configuration and asks for confirmation:
 
@@ -113,9 +128,13 @@ The wizard displays the final configuration and asks for confirmation:
 ✅ Written to .newbranchrc.json
 ```
 
+::: tip
+When writing to **git config**, each value is saved as a separate `new-branch.*` key (e.g. `new-branch.pattern`, `new-branch.defaultType`). Pattern aliases are stored as `new-branch.patterns.<name>`.
+:::
+
 ## Default Config (`--yes`)
 
-When using `--yes`, the wizard writes this configuration without any prompts:
+When using `--yes`, the wizard writes this configuration to `.newbranchrc.json` without any prompts:
 
 ```json
 {
@@ -131,10 +150,12 @@ When using `--yes`, the wizard writes this configuration without any prompts:
 
 ## Overwriting Existing Config
 
-If a `.newbranchrc.json` already exists:
+For file-based targets (`.newbranchrc.json` and `package.json`):
 
 - **Interactive mode**: the wizard asks whether to overwrite or abort.
 - **`--yes` mode**: the file is overwritten with a warning message.
+
+For **git config**, values are always overwritten (git config is append/replace by nature).
 
 ## After Init
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,9 @@ features:
   - icon: 🔄
     title: Composable Transforms
     details: Chain transforms like slugify, kebab, max, and replace to shape variable values exactly the way you need.
+  - icon: 🚀
+    title: Init Wizard
+    details: Run new-branch init to bootstrap your .newbranchrc.json interactively with live preview — or use --yes for sensible defaults.
   - icon: ⚙️
     title: Flexible Configuration
     details: Configure via .newbranchrc.json, package.json, or git config. CLI flags always take precedence.

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -6,6 +6,7 @@ Complete reference for all `new-branch` command-line options.
 
 ```bash
 new-branch [options]
+new-branch init [--yes]
 ```
 
 Also available as git subcommands:
@@ -14,6 +15,13 @@ Also available as git subcommands:
 git new-branch [options]
 git nb [options]
 ```
+
+## Subcommands
+
+| Subcommand   | Description                                                                |
+| ------------ | -------------------------------------------------------------------------- |
+| `init`       | Launch the interactive config wizard to create a `.newbranchrc.json` file. |
+| `init --yes` | Create a `.newbranchrc.json` with sensible defaults (no prompts).          |
 
 ## Options
 
@@ -29,12 +37,12 @@ git nb [options]
 
 ### Behavior Options
 
-| Option                    | Type      | Default | Description                                                                           |
-| ------------------------- | --------- | ------- | ------------------------------------------------------------------------------------- |
-| `-L, --max-length <n>`    | `number`  | —       | Maximum length for the final branch name. Truncates from the end if the name exceeds. |
-| `--create`                | `boolean` | `false` | Create the branch using `git switch -c` and switch to it.                             |
-| `--no-prompt`             | `boolean` | `false` | Disable interactive prompts. Fails if required values are missing.                    |
-| `--quiet`                 | `boolean` | `false` | Suppress non-essential output. Only prints the branch name.                           |
+| Option                 | Type      | Default | Description                                                                           |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------------------------- |
+| `-L, --max-length <n>` | `number`  | —       | Maximum length for the final branch name. Truncates from the end if the name exceeds. |
+| `--create`             | `boolean` | `false` | Create the branch using `git switch -c` and switch to it.                             |
+| `--no-prompt`          | `boolean` | `false` | Disable interactive prompts. Fails if required values are missing.                    |
+| `--quiet`              | `boolean` | `false` | Suppress non-essential output. Only prints the branch name.                           |
 
 ### Didactic Options
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -57,6 +57,11 @@ vi.mock("@/didactic/explain.js", () => ({
   explain: (...args: unknown[]) => explainMock(...args),
 }));
 
+const runInitMock = vi.fn();
+vi.mock("@/init/runInit.js", () => ({
+  runInit: (...args: unknown[]) => runInitMock(...args),
+}));
+
 const sanitizeGitRefMock = vi.fn();
 vi.mock("@/git/sanitizeGitRef.js", () => ({
   sanitizeGitRef: (...args: unknown[]) => sanitizeGitRefMock(...args),
@@ -192,6 +197,34 @@ describe("cli.ts (run)", () => {
     expect(renderPatternMock).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("delegates to runInit when argv starts with 'init'", async () => {
+    setArgv(["init"]);
+    runInitMock.mockResolvedValue(undefined);
+
+    await run();
+
+    expect(runInitMock).toHaveBeenCalledWith({ yes: false });
+    expect(parseArgsMock).not.toHaveBeenCalled();
+  });
+
+  it("passes --yes flag to runInit", async () => {
+    setArgv(["init", "--yes"]);
+    runInitMock.mockResolvedValue(undefined);
+
+    await run();
+
+    expect(runInitMock).toHaveBeenCalledWith({ yes: true });
+  });
+
+  it("passes -y flag to runInit", async () => {
+    setArgv(["init", "-y"]);
+    runInitMock.mockResolvedValue(undefined);
+
+    await run();
+
+    expect(runInitMock).toHaveBeenCalledWith({ yes: true });
   });
 
   it("uses CLI --pattern over package.json config and prints branch name", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import { createBranch } from "@/git/createBranch.js";
 import { listTransforms } from "@/didactic/listTransforms.js";
 import { printConfig } from "@/didactic/printConfig.js";
 import { explain } from "@/didactic/explain.js";
+import { runInit } from "@/init/runInit.js";
 
 /**
  * Success variant of the {@link Result} union.
@@ -186,6 +187,16 @@ export async function run(): Promise<void> {
   // - `tsx` puts the script path (e.g. `src/cli.ts`) as the first item in `process.argv.slice(2)`.
   //   That script path is not a flag, so we strip leading non-flag arguments.
   let argv = process.argv.slice(2);
+
+  // --- Subcommand: init ---
+  // Check before stripping positional entries so "init" is not removed.
+  const initIdx = argv.indexOf("init");
+  if (initIdx !== -1) {
+    const initArgv = argv.slice(initIdx + 1);
+    const yes = initArgv.includes("--yes") || initArgv.includes("-y");
+    await runInit({ yes });
+    return;
+  }
 
   // Strip leading positional entries like `src/cli.ts` (common when running via `tsx`).
   while (argv.length > 0 && argv[0] !== "--" && !argv[0].startsWith("-")) {

--- a/src/init/defaults.test.ts
+++ b/src/init/defaults.test.ts
@@ -79,20 +79,12 @@ describe("buildPattern", () => {
   });
 
   it("handles multiple transforms with semicolons", () => {
-    const result = buildPattern(
-      ["type", "title"],
-      { title: "slugify;max:30" },
-      ["/"],
-    );
+    const result = buildPattern(["type", "title"], { title: "slugify;max:30" }, ["/"]);
     expect(result).toBe("{type}/{title:slugify;max:30}");
   });
 
   it("handles multiple separators", () => {
-    const result = buildPattern(
-      ["type", "id", "title"],
-      { title: "slugify" },
-      ["/", "-"],
-    );
+    const result = buildPattern(["type", "id", "title"], { title: "slugify" }, ["/", "-"]);
     expect(result).toBe("{type}/{id}-{title:slugify}");
   });
 

--- a/src/init/defaults.test.ts
+++ b/src/init/defaults.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  VARIABLE_OPTIONS,
+  TITLE_TRANSFORM_PRESETS,
+  DEFAULT_TYPES,
+  DEFAULT_SEPARATOR,
+  buildPattern,
+} from "./defaults.js";
+
+describe("VARIABLE_OPTIONS", () => {
+  it("contains at least type, title, and id", () => {
+    const names = VARIABLE_OPTIONS.map((v) => v.name);
+    expect(names).toContain("type");
+    expect(names).toContain("title");
+    expect(names).toContain("id");
+  });
+
+  it("has type, title, and id selected by default", () => {
+    const selected = VARIABLE_OPTIONS.filter((v) => v.selected).map((v) => v.name);
+    expect(selected).toContain("type");
+    expect(selected).toContain("title");
+    expect(selected).toContain("id");
+  });
+
+  it("each variable has name and description", () => {
+    for (const v of VARIABLE_OPTIONS) {
+      expect(v.name).toBeTruthy();
+      expect(v.description).toBeTruthy();
+    }
+  });
+});
+
+describe("TITLE_TRANSFORM_PRESETS", () => {
+  it("contains at least slugify and none options", () => {
+    const labels = TITLE_TRANSFORM_PRESETS.map((p) => p.label);
+    expect(labels.some((l) => l.includes("slugify"))).toBe(true);
+    expect(labels.some((l) => l.includes("none"))).toBe(true);
+  });
+
+  it("each preset has a label and chain", () => {
+    for (const p of TITLE_TRANSFORM_PRESETS) {
+      expect(p.label).toBeTruthy();
+      expect(typeof p.chain).toBe("string");
+    }
+  });
+});
+
+describe("DEFAULT_TYPES", () => {
+  it("contains feat, fix, and chore", () => {
+    const values = DEFAULT_TYPES.map((t) => t.value);
+    expect(values).toContain("feat");
+    expect(values).toContain("fix");
+    expect(values).toContain("chore");
+  });
+
+  it("each type has value and label", () => {
+    for (const t of DEFAULT_TYPES) {
+      expect(t.value).toBeTruthy();
+      expect(t.label).toBeTruthy();
+    }
+  });
+});
+
+describe("DEFAULT_SEPARATOR", () => {
+  it("is a slash", () => {
+    expect(DEFAULT_SEPARATOR).toBe("/");
+  });
+});
+
+describe("buildPattern", () => {
+  it("builds a simple pattern without transforms", () => {
+    const result = buildPattern(["type", "title"], {}, ["/"]);
+    expect(result).toBe("{type}/{title}");
+  });
+
+  it("applies transforms to variables", () => {
+    const result = buildPattern(["type", "title"], { title: "slugify" }, ["/"]);
+    expect(result).toBe("{type}/{title:slugify}");
+  });
+
+  it("handles multiple transforms with semicolons", () => {
+    const result = buildPattern(
+      ["type", "title"],
+      { title: "slugify;max:30" },
+      ["/"],
+    );
+    expect(result).toBe("{type}/{title:slugify;max:30}");
+  });
+
+  it("handles multiple separators", () => {
+    const result = buildPattern(
+      ["type", "id", "title"],
+      { title: "slugify" },
+      ["/", "-"],
+    );
+    expect(result).toBe("{type}/{id}-{title:slugify}");
+  });
+
+  it("handles a single variable", () => {
+    const result = buildPattern(["title"], { title: "kebab" }, []);
+    expect(result).toBe("{title:kebab}");
+  });
+
+  it("handles all variables with transforms", () => {
+    const result = buildPattern(
+      ["type", "title", "id"],
+      { type: "lower", title: "slugify", id: "upper" },
+      ["/", "-"],
+    );
+    expect(result).toBe("{type:lower}/{title:slugify}-{id:upper}");
+  });
+
+  it("returns empty string for empty variables", () => {
+    const result = buildPattern([], {}, []);
+    expect(result).toBe("");
+  });
+});

--- a/src/init/defaults.ts
+++ b/src/init/defaults.ts
@@ -1,0 +1,93 @@
+/**
+ * @module init/defaults
+ *
+ * Default values and choices for the init wizard.
+ */
+
+/**
+ * A selectable variable option in the wizard.
+ */
+export type VariableOption = {
+  /** Variable name used in patterns. */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** Whether this variable is selected by default. */
+  selected: boolean;
+};
+
+/**
+ * Available variables to choose from.
+ */
+export const VARIABLE_OPTIONS: VariableOption[] = [
+  { name: "type", description: "Branch type (feat, fix, chore...)", selected: true },
+  { name: "title", description: "Task or feature title", selected: true },
+  { name: "id", description: "Task identifier (PROJ-123)", selected: true },
+  { name: "date", description: "Current date (YYYY-MM-DD)", selected: false },
+  { name: "dateCompact", description: "Current date (YYYYMMDD)", selected: false },
+  { name: "userName", description: "Git user name", selected: false },
+  { name: "shortSha", description: "Short commit SHA", selected: false },
+  { name: "currentBranch", description: "Current branch name", selected: false },
+  { name: "repoName", description: "Repository name", selected: false },
+  { name: "lastTag", description: "Most recent git tag", selected: false },
+];
+
+/**
+ * Transform presets for the title variable.
+ */
+export type TransformPreset = {
+  /** Display label in the wizard. */
+  label: string;
+  /** Transform chain to apply (e.g. "slugify;max:30"). */
+  chain: string;
+};
+
+/**
+ * Pre-configured transform presets for the title variable.
+ */
+export const TITLE_TRANSFORM_PRESETS: TransformPreset[] = [
+  { label: "slugify — URL-safe slug", chain: "slugify" },
+  { label: "slugify + max — Slug with length limit", chain: "slugify;max:30" },
+  { label: "kebab — kebab-case", chain: "kebab" },
+  { label: "snake — snake_case", chain: "snake" },
+  { label: "none — Leave as-is", chain: "" },
+];
+
+/**
+ * Common branch type presets.
+ */
+export const DEFAULT_TYPES = [
+  { value: "feat", label: "Feature" },
+  { value: "fix", label: "Bug Fix" },
+  { value: "chore", label: "Chore" },
+  { value: "docs", label: "Documentation" },
+  { value: "refactor", label: "Refactor" },
+];
+
+/**
+ * Default separator used between pattern parts.
+ */
+export const DEFAULT_SEPARATOR = "/";
+
+/**
+ * Builds a pattern string from selected variables, transforms, and separators.
+ *
+ * @param variables - Ordered list of variable names to include.
+ * @param transforms - Map of variable name to transform chain (e.g. { title: "slugify;max:30" }).
+ * @param separators - Separators between variables (array of length variables.length - 1).
+ * @returns A pattern string.
+ */
+export function buildPattern(
+  variables: string[],
+  transforms: Record<string, string>,
+  separators: string[],
+): string {
+  return variables
+    .map((v, i) => {
+      const t = transforms[v];
+      const varPart = t ? `{${v}:${t}}` : `{${v}}`;
+      const sep = i < separators.length ? separators[i] : "";
+      return varPart + sep;
+    })
+    .join("");
+}

--- a/src/init/preview.test.ts
+++ b/src/init/preview.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { renderPreview, MOCK_VALUES } from "./preview.js";
+
+describe("renderPreview", () => {
+  it("renders a simple pattern with type and title", () => {
+    const result = renderPreview("{type}/{title:slugify}");
+    expect(result).toBe("feat/add-login-page");
+  });
+
+  it("renders a pattern with id", () => {
+    const result = renderPreview("{type}/{id}-{title:slugify}");
+    expect(result).toBe("feat/PROJ-123-add-login-page");
+  });
+
+  it("renders a pattern with date variables", () => {
+    const result = renderPreview("{dateCompact}/{title:kebab}");
+    expect(result).toBe("20260228/add-login-page");
+  });
+
+  it("renders a pattern with git variables", () => {
+    const result = renderPreview("{userName}/{title:snake}");
+    expect(result).toBe("john-doe/add_login_page");
+  });
+
+  it("returns (invalid pattern) for malformed patterns", () => {
+    const result = renderPreview("{unclosed");
+    expect(result).toBe("(invalid pattern)");
+  });
+
+  it("handles empty pattern gracefully", () => {
+    const result = renderPreview("");
+    // Empty pattern produces empty string, which sanitizeGitRef may handle
+    expect(typeof result).toBe("string");
+  });
+
+  it("MOCK_VALUES contains all expected keys", () => {
+    const expectedKeys = [
+      "type",
+      "title",
+      "id",
+      "year",
+      "month",
+      "day",
+      "date",
+      "dateCompact",
+      "currentBranch",
+      "shortSha",
+      "repoName",
+      "userName",
+      "lastTag",
+    ];
+    for (const key of expectedKeys) {
+      expect(MOCK_VALUES).toHaveProperty(key);
+      expect(typeof MOCK_VALUES[key]).toBe("string");
+    }
+  });
+});

--- a/src/init/preview.ts
+++ b/src/init/preview.ts
@@ -1,0 +1,51 @@
+/**
+ * @module init/preview
+ *
+ * Utility to render a live preview of a pattern using deterministic mock
+ * values, used by the init wizard to show the user what their branch name
+ * will look like.
+ */
+
+import { parsePattern } from "@/pattern/parsePattern.js";
+import { renderPattern } from "@/pattern/transforms/renderPattern.js";
+import { defaultTransforms } from "@/pattern/transforms/index.js";
+import { sanitizeGitRef } from "@/git/sanitizeGitRef.js";
+
+/**
+ * Deterministic mock values used for previewing patterns.
+ * These produce realistic-looking branch names.
+ */
+export const MOCK_VALUES: Record<string, string> = {
+  type: "feat",
+  title: "Add login page",
+  id: "PROJ-123",
+  year: "2026",
+  month: "02",
+  day: "28",
+  date: "2026-02-28",
+  dateCompact: "20260228",
+  currentBranch: "main",
+  shortSha: "a1b2c3d",
+  repoName: "my-project",
+  userName: "john-doe",
+  lastTag: "v1.0.0",
+};
+
+/**
+ * Renders a pattern string into a preview branch name using mock values.
+ *
+ * @param pattern - The pattern string to preview.
+ * @returns The rendered and sanitized branch name, or an error message.
+ */
+export function renderPreview(pattern: string): string {
+  try {
+    const ast = parsePattern(pattern);
+    const rendered = renderPattern(ast, MOCK_VALUES, {
+      transforms: defaultTransforms,
+      strict: false,
+    });
+    return sanitizeGitRef(rendered);
+  } catch {
+    return "(invalid pattern)";
+  }
+}

--- a/src/init/runInit.test.ts
+++ b/src/init/runInit.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+
+// ---- Mocks ----
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  writeFile: vi.fn(),
+}));
+
+const confirmMock = vi.fn();
+const selectMock = vi.fn();
+const checkboxMock = vi.fn();
+const inputMock = vi.fn();
+
+vi.mock("@inquirer/prompts", () => ({
+  confirm: (...args: unknown[]) => confirmMock(...args),
+  select: (...args: unknown[]) => selectMock(...args),
+  checkbox: (...args: unknown[]) => checkboxMock(...args),
+  input: (...args: unknown[]) => inputMock(...args),
+}));
+
+// Mock validate to be a no-op (we test validation elsewhere)
+vi.mock("@/config/validate.js", () => ({
+  validateProjectConfigFinal: vi.fn(),
+}));
+
+import { runInit } from "./runInit.js";
+
+// ---- Helpers ----
+
+const existsSyncMock = existsSync as unknown as ReturnType<typeof vi.fn>;
+const writeFileMock = writeFile as unknown as ReturnType<typeof vi.fn>;
+
+describe("runInit", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsSyncMock.mockReturnValue(false);
+    writeFileMock.mockResolvedValue(undefined);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  describe("--yes mode (non-interactive)", () => {
+    it("writes default config without prompting", async () => {
+      await runInit({ yes: true, cwd: "/tmp/test" });
+
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(checkboxMock).not.toHaveBeenCalled();
+      expect(selectMock).not.toHaveBeenCalled();
+
+      expect(writeFileMock).toHaveBeenCalledOnce();
+      const [path, content] = writeFileMock.mock.calls[0];
+      expect(path).toContain(".newbranchrc.json");
+
+      const config = JSON.parse(content);
+      expect(config.pattern).toBe("{type}/{title:slugify}-{id}");
+      expect(config.types).toBeInstanceOf(Array);
+      expect(config.types.length).toBe(3);
+      expect(config.defaultType).toBe("feat");
+    });
+
+    it("warns about existing config in --yes mode", async () => {
+      existsSyncMock.mockReturnValue(true);
+
+      await runInit({ yes: true, cwd: "/tmp/test" });
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Overwriting"));
+      expect(writeFileMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("existing config detection", () => {
+    it("asks to overwrite when config exists", async () => {
+      existsSyncMock.mockReturnValue(true);
+      confirmMock.mockResolvedValueOnce(false); // Don't overwrite
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(confirmMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("already exists"),
+        }),
+      );
+      expect(writeFileMock).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith("Aborted.");
+    });
+
+    it("proceeds when user confirms overwrite", async () => {
+      existsSyncMock.mockReturnValue(true);
+      // Overwrite: yes
+      confirmMock.mockResolvedValueOnce(true);
+      // Build interactive config — provide minimal wizard answers
+      checkboxMock.mockResolvedValueOnce(["type", "title"]);
+      selectMock.mockResolvedValueOnce("/"); // separator
+      selectMock.mockResolvedValueOnce("slugify"); // transform
+      // Define types? no
+      confirmMock.mockResolvedValueOnce(false);
+      // Define aliases? no
+      confirmMock.mockResolvedValueOnce(false);
+      // Write file? yes
+      confirmMock.mockResolvedValueOnce(true);
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(writeFileMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("interactive wizard", () => {
+    it("builds config from wizard answers", async () => {
+      // Select variables
+      checkboxMock.mockResolvedValueOnce(["type", "title", "id"]);
+      // Separators (2 separators for 3 variables)
+      selectMock.mockResolvedValueOnce("/");  // between type and title
+      selectMock.mockResolvedValueOnce("-");  // between title and id
+      // Transforms for title (type and id are not text vars)
+      selectMock.mockResolvedValueOnce("slugify");
+      // Define types? yes
+      confirmMock.mockResolvedValueOnce(true);
+      // Use defaults? yes
+      confirmMock.mockResolvedValueOnce(true);
+      // Add more? no
+      confirmMock.mockResolvedValueOnce(false);
+      // Default type selection
+      selectMock.mockResolvedValueOnce("feat");
+      // Define aliases? no
+      confirmMock.mockResolvedValueOnce(false);
+      // Write file? yes
+      confirmMock.mockResolvedValueOnce(true);
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(writeFileMock).toHaveBeenCalledOnce();
+      const [, content] = writeFileMock.mock.calls[0];
+      const config = JSON.parse(content);
+
+      expect(config.pattern).toBe("{type}/{title:slugify}-{id}");
+      expect(config.types).toEqual([
+        { value: "feat", label: "Feature" },
+        { value: "fix", label: "Bug Fix" },
+        { value: "chore", label: "Chore" },
+      ]);
+      expect(config.defaultType).toBe("feat");
+    });
+
+    it("aborts when user declines to write", async () => {
+      checkboxMock.mockResolvedValueOnce(["type", "title"]);
+      selectMock.mockResolvedValueOnce("/");
+      selectMock.mockResolvedValueOnce("slugify");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      confirmMock.mockResolvedValueOnce(false); // no aliases
+      confirmMock.mockResolvedValueOnce(false); // decline write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(writeFileMock).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith("Aborted.");
+    });
+
+    it("exits when no variables selected", async () => {
+      checkboxMock.mockResolvedValueOnce([]);
+
+      await expect(runInit({ cwd: "/tmp/test" })).rejects.toThrow("process.exit");
+      expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it("handles aliased patterns", async () => {
+      checkboxMock.mockResolvedValueOnce(["type", "title"]);
+      selectMock.mockResolvedValueOnce("/");
+      selectMock.mockResolvedValueOnce("kebab");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      // Define aliases? yes
+      confirmMock.mockResolvedValueOnce(true);
+      // Alias name
+      inputMock.mockResolvedValueOnce("hotfix");
+      // Alias pattern
+      inputMock.mockResolvedValueOnce("hotfix/{title:slugify}");
+      // Add more? no
+      confirmMock.mockResolvedValueOnce(false);
+      // Write file? yes
+      confirmMock.mockResolvedValueOnce(true);
+
+      await runInit({ cwd: "/tmp/test" });
+
+      const [, content] = writeFileMock.mock.calls[0];
+      const config = JSON.parse(content);
+
+      expect(config.patterns).toEqual({
+        hotfix: "hotfix/{title:slugify}",
+      });
+    });
+
+    it("handles transform with max length prompt", async () => {
+      checkboxMock.mockResolvedValueOnce(["title"]);
+      // No separators needed (single var)
+      // Transform with max
+      selectMock.mockResolvedValueOnce("slugify;max:30");
+      inputMock.mockResolvedValueOnce("50"); // max length
+      confirmMock.mockResolvedValueOnce(false); // no types
+      confirmMock.mockResolvedValueOnce(false); // no aliases
+      confirmMock.mockResolvedValueOnce(true);  // write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      const [, content] = writeFileMock.mock.calls[0];
+      const config = JSON.parse(content);
+      expect(config.pattern).toBe("{title:slugify;max:50}");
+    });
+  });
+});

--- a/src/init/runInit.test.ts
+++ b/src/init/runInit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { existsSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 
 // ---- Mocks ----
 
@@ -9,7 +9,13 @@ vi.mock("node:fs", () => ({
 }));
 
 vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
   writeFile: vi.fn(),
+}));
+
+const execaMock = vi.fn();
+vi.mock("execa", () => ({
+  execa: (...args: unknown[]) => execaMock(...args),
 }));
 
 const confirmMock = vi.fn();
@@ -35,6 +41,7 @@ import { runInit } from "./runInit.js";
 
 const existsSyncMock = existsSync as unknown as ReturnType<typeof vi.fn>;
 const writeFileMock = writeFile as unknown as ReturnType<typeof vi.fn>;
+const readFileMock = readFile as unknown as ReturnType<typeof vi.fn>;
 
 describe("runInit", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -44,6 +51,8 @@ describe("runInit", () => {
     vi.clearAllMocks();
     existsSyncMock.mockReturnValue(false);
     writeFileMock.mockResolvedValue(undefined);
+    readFileMock.mockRejectedValue(new Error("ENOENT"));
+    execaMock.mockResolvedValue({ stdout: "" });
     logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");
@@ -56,7 +65,7 @@ describe("runInit", () => {
   });
 
   describe("--yes mode (non-interactive)", () => {
-    it("writes default config without prompting", async () => {
+    it("writes default config to .newbranchrc.json without prompting", async () => {
       await runInit({ yes: true, cwd: "/tmp/test" });
 
       expect(confirmMock).not.toHaveBeenCalled();
@@ -84,9 +93,79 @@ describe("runInit", () => {
     });
   });
 
+  describe("config target selection", () => {
+    it("prompts for config target in interactive mode", async () => {
+      // Target: .newbranchrc.json
+      selectMock.mockResolvedValueOnce("rc");
+      // Minimal wizard
+      checkboxMock.mockResolvedValueOnce(["title"]);
+      selectMock.mockResolvedValueOnce("slugify");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      confirmMock.mockResolvedValueOnce(false); // no aliases
+      confirmMock.mockResolvedValueOnce(true); // write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(selectMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Where do you want to save"),
+        }),
+      );
+      expect(writeFileMock).toHaveBeenCalledOnce();
+      const [path] = writeFileMock.mock.calls[0];
+      expect(path).toContain(".newbranchrc.json");
+    });
+
+    it("writes to package.json when selected", async () => {
+      readFileMock.mockResolvedValueOnce(JSON.stringify({ name: "my-project", version: "1.0.0" }));
+      // Target: package.json
+      selectMock.mockResolvedValueOnce("package.json");
+      // Minimal wizard
+      checkboxMock.mockResolvedValueOnce(["title"]);
+      selectMock.mockResolvedValueOnce("kebab");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      confirmMock.mockResolvedValueOnce(false); // no aliases
+      confirmMock.mockResolvedValueOnce(true); // write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(writeFileMock).toHaveBeenCalledOnce();
+      const [path, content] = writeFileMock.mock.calls[0];
+      expect(path).toContain("package.json");
+      const pkg = JSON.parse(content);
+      expect(pkg.name).toBe("my-project");
+      expect(pkg["new-branch"]).toBeDefined();
+      expect(pkg["new-branch"].pattern).toBe("{title:kebab}");
+    });
+
+    it("writes to git config when selected", async () => {
+      // Target: git config
+      selectMock.mockResolvedValueOnce("git");
+      // Minimal wizard
+      checkboxMock.mockResolvedValueOnce(["type", "title"]);
+      selectMock.mockResolvedValueOnce("/");
+      selectMock.mockResolvedValueOnce("slugify");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      confirmMock.mockResolvedValueOnce(false); // no aliases
+      confirmMock.mockResolvedValueOnce(true); // write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(writeFileMock).not.toHaveBeenCalled();
+      expect(execaMock).toHaveBeenCalledWith("git", [
+        "config",
+        "--local",
+        "new-branch.pattern",
+        "{type}/{title:slugify}",
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("git config"));
+    });
+  });
+
   describe("existing config detection", () => {
-    it("asks to overwrite when config exists", async () => {
+    it("asks to overwrite when rc config exists", async () => {
       existsSyncMock.mockReturnValue(true);
+      selectMock.mockResolvedValueOnce("rc"); // target
       confirmMock.mockResolvedValueOnce(false); // Don't overwrite
 
       await runInit({ cwd: "/tmp/test" });
@@ -100,11 +179,29 @@ describe("runInit", () => {
       expect(logSpy).toHaveBeenCalledWith("Aborted.");
     });
 
+    it("skips overwrite check for git config target", async () => {
+      existsSyncMock.mockReturnValue(true);
+      selectMock.mockResolvedValueOnce("git"); // target
+      // Minimal wizard (no overwrite prompt expected)
+      checkboxMock.mockResolvedValueOnce(["title"]);
+      selectMock.mockResolvedValueOnce("slugify");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      confirmMock.mockResolvedValueOnce(false); // no aliases
+      confirmMock.mockResolvedValueOnce(true); // write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      // First confirm should NOT be about overwriting
+      expect(confirmMock.mock.calls[0][0].message).not.toMatch(/already exists/);
+      expect(execaMock).toHaveBeenCalled();
+    });
+
     it("proceeds when user confirms overwrite", async () => {
       existsSyncMock.mockReturnValue(true);
+      selectMock.mockResolvedValueOnce("rc"); // target
       // Overwrite: yes
       confirmMock.mockResolvedValueOnce(true);
-      // Build interactive config — provide minimal wizard answers
+      // Build interactive config
       checkboxMock.mockResolvedValueOnce(["type", "title"]);
       selectMock.mockResolvedValueOnce("/"); // separator
       selectMock.mockResolvedValueOnce("slugify"); // transform
@@ -123,11 +220,12 @@ describe("runInit", () => {
 
   describe("interactive wizard", () => {
     it("builds config from wizard answers", async () => {
+      selectMock.mockResolvedValueOnce("rc"); // target
       // Select variables
       checkboxMock.mockResolvedValueOnce(["type", "title", "id"]);
       // Separators (2 separators for 3 variables)
-      selectMock.mockResolvedValueOnce("/");  // between type and title
-      selectMock.mockResolvedValueOnce("-");  // between title and id
+      selectMock.mockResolvedValueOnce("/"); // between type and title
+      selectMock.mockResolvedValueOnce("-"); // between title and id
       // Transforms for title (type and id are not text vars)
       selectMock.mockResolvedValueOnce("slugify");
       // Define types? yes
@@ -159,6 +257,7 @@ describe("runInit", () => {
     });
 
     it("aborts when user declines to write", async () => {
+      selectMock.mockResolvedValueOnce("rc"); // target
       checkboxMock.mockResolvedValueOnce(["type", "title"]);
       selectMock.mockResolvedValueOnce("/");
       selectMock.mockResolvedValueOnce("slugify");
@@ -173,6 +272,7 @@ describe("runInit", () => {
     });
 
     it("exits when no variables selected", async () => {
+      selectMock.mockResolvedValueOnce("rc"); // target
       checkboxMock.mockResolvedValueOnce([]);
 
       await expect(runInit({ cwd: "/tmp/test" })).rejects.toThrow("process.exit");
@@ -180,6 +280,7 @@ describe("runInit", () => {
     });
 
     it("handles aliased patterns", async () => {
+      selectMock.mockResolvedValueOnce("rc"); // target
       checkboxMock.mockResolvedValueOnce(["type", "title"]);
       selectMock.mockResolvedValueOnce("/");
       selectMock.mockResolvedValueOnce("kebab");
@@ -206,6 +307,7 @@ describe("runInit", () => {
     });
 
     it("handles transform with max length prompt", async () => {
+      selectMock.mockResolvedValueOnce("rc"); // target
       checkboxMock.mockResolvedValueOnce(["title"]);
       // No separators needed (single var)
       // Transform with max
@@ -213,13 +315,36 @@ describe("runInit", () => {
       inputMock.mockResolvedValueOnce("50"); // max length
       confirmMock.mockResolvedValueOnce(false); // no types
       confirmMock.mockResolvedValueOnce(false); // no aliases
-      confirmMock.mockResolvedValueOnce(true);  // write
+      confirmMock.mockResolvedValueOnce(true); // write
 
       await runInit({ cwd: "/tmp/test" });
 
       const [, content] = writeFileMock.mock.calls[0];
       const config = JSON.parse(content);
       expect(config.pattern).toBe("{title:slugify;max:50}");
+    });
+
+    it("writes pattern aliases as separate git config keys", async () => {
+      selectMock.mockResolvedValueOnce("git"); // target
+      checkboxMock.mockResolvedValueOnce(["type", "title"]);
+      selectMock.mockResolvedValueOnce("/");
+      selectMock.mockResolvedValueOnce("slugify");
+      confirmMock.mockResolvedValueOnce(false); // no types
+      // Define aliases? yes
+      confirmMock.mockResolvedValueOnce(true);
+      inputMock.mockResolvedValueOnce("hotfix");
+      inputMock.mockResolvedValueOnce("hotfix/{title:slugify}");
+      confirmMock.mockResolvedValueOnce(false); // no more aliases
+      confirmMock.mockResolvedValueOnce(true); // write
+
+      await runInit({ cwd: "/tmp/test" });
+
+      expect(execaMock).toHaveBeenCalledWith("git", [
+        "config",
+        "--local",
+        "new-branch.patterns.hotfix",
+        "hotfix/{title:slugify}",
+      ]);
     });
   });
 });

--- a/src/init/runInit.ts
+++ b/src/init/runInit.ts
@@ -1,24 +1,26 @@
 /**
  * @module init/runInit
  *
- * Interactive wizard that walks the user through creating a `.newbranchrc.json`
- * configuration file.
+ * Interactive wizard that walks the user through creating a `new-branch`
+ * configuration, written to the target of the user's choice.
  *
  * @remarks
  * The wizard flow:
- * 1. Detect existing config → offer to overwrite or abort
- * 2. Select variables to include in the pattern
- * 3. Choose separators between variables
- * 4. Choose transforms (for title and other text variables)
- * 5. Show live preview
- * 6. Optionally define branch types
- * 7. Optionally define pattern aliases
- * 8. Show final config → write to disk
+ * 1. Choose config target (`.newbranchrc.json`, `package.json`, or `git config`)
+ * 2. Detect existing config → offer to overwrite or abort
+ * 3. Select variables to include in the pattern
+ * 4. Choose separators between variables
+ * 5. Choose transforms (for title and other text variables)
+ * 6. Show live preview
+ * 7. Optionally define branch types
+ * 8. Optionally define pattern aliases
+ * 9. Show final config → write to chosen target
  */
 
 import { existsSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { execa } from "execa";
 import { input, select, confirm, checkbox } from "@inquirer/prompts";
 import type { ProjectConfig, BranchType } from "@/config/types.js";
 import { validateProjectConfigFinal } from "@/config/validate.js";
@@ -30,7 +32,12 @@ import {
 } from "@/init/defaults.js";
 import { renderPreview } from "@/init/preview.js";
 
-const CONFIG_FILE = ".newbranchrc.json";
+const RC_FILE = ".newbranchrc.json";
+
+/**
+ * Where the config should be written.
+ */
+export type ConfigTarget = "rc" | "package.json" | "git";
 
 /**
  * Options for {@link runInit}.
@@ -49,20 +56,39 @@ export type InitOptions = {
  */
 export async function runInit(options: InitOptions = {}): Promise<void> {
   const cwd = options.cwd ?? process.cwd();
-  const configPath = resolve(cwd, CONFIG_FILE);
 
-  // Step 0: Detect existing config
-  if (existsSync(configPath)) {
-    if (options.yes) {
-      console.log(`⚠️  Overwriting existing ${CONFIG_FILE}`);
-    } else {
-      const overwrite = await confirm({
-        message: `${CONFIG_FILE} already exists. Overwrite?`,
-        default: false,
+  // Step 0: Choose config target
+  const target: ConfigTarget = options.yes
+    ? "rc"
+    : await select({
+        message: "Where do you want to save the configuration?",
+        choices: [
+          { name: ".newbranchrc.json — Dedicated config file", value: "rc" as ConfigTarget },
+          {
+            name: 'package.json — Under the "new-branch" key',
+            value: "package.json" as ConfigTarget,
+          },
+          { name: "git config — Local repo git config", value: "git" as ConfigTarget },
+        ],
+        default: "rc" as ConfigTarget,
       });
-      if (!overwrite) {
-        console.log("Aborted.");
-        return;
+
+  // Step 1: Detect existing config
+  if (target !== "git") {
+    const filePath = resolve(cwd, target === "rc" ? RC_FILE : "package.json");
+    if (existsSync(filePath)) {
+      if (options.yes) {
+        console.log(`⚠️  Overwriting existing ${target === "rc" ? RC_FILE : "package.json"}`);
+      } else {
+        const label = target === "rc" ? RC_FILE : `"new-branch" key in package.json`;
+        const overwrite = await confirm({
+          message: `${label} already exists. Overwrite?`,
+          default: false,
+        });
+        if (!overwrite) {
+          console.log("Aborted.");
+          return;
+        }
       }
     }
   }
@@ -85,8 +111,10 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
   console.log(json);
 
   if (!options.yes) {
+    const targetLabel =
+      target === "rc" ? RC_FILE : target === "package.json" ? "package.json" : "git config (local)";
     const proceed = await confirm({
-      message: `Write to ${CONFIG_FILE}?`,
+      message: `Write to ${targetLabel}?`,
       default: true,
     });
     if (!proceed) {
@@ -95,8 +123,81 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
     }
   }
 
-  await writeFile(configPath, json, "utf-8");
-  console.log(`✅ Written to ${CONFIG_FILE}`);
+  await writeConfig(config, target, cwd);
+}
+
+/**
+ * Writes the config to the chosen target.
+ *
+ * @param config - The validated project config.
+ * @param target - Where to write the config.
+ * @param cwd    - Working directory.
+ */
+async function writeConfig(
+  config: ProjectConfig,
+  target: ConfigTarget,
+  cwd: string,
+): Promise<void> {
+  switch (target) {
+    case "rc": {
+      const rcPath = resolve(cwd, RC_FILE);
+      const json = JSON.stringify(config, null, 2) + "\n";
+      await writeFile(rcPath, json, "utf-8");
+      console.log(`✅ Written to ${RC_FILE}`);
+      break;
+    }
+
+    case "package.json": {
+      const pkgPath = resolve(cwd, "package.json");
+      let pkg: Record<string, unknown> = {};
+      try {
+        const raw = await readFile(pkgPath, "utf-8");
+        pkg = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        // package.json doesn't exist yet — we'll create one
+      }
+      pkg["new-branch"] = config;
+      const json = JSON.stringify(pkg, null, 2) + "\n";
+      await writeFile(pkgPath, json, "utf-8");
+      console.log(`✅ Written to package.json ("new-branch" key)`);
+      break;
+    }
+
+    case "git": {
+      await writeGitConfig(config);
+      console.log("✅ Written to git config (local)");
+      break;
+    }
+  }
+}
+
+/**
+ * Writes config values as local git config entries under the `new-branch.*` namespace.
+ *
+ * @remarks
+ * git config only supports flat key-value pairs, so:
+ * - `pattern` → `new-branch.pattern`
+ * - `defaultType` → `new-branch.defaultType`
+ * - `types` and `patterns` → serialized as JSON strings
+ *
+ * @param config - The project config to write.
+ */
+async function writeGitConfig(config: ProjectConfig): Promise<void> {
+  if (config.pattern) {
+    await execa("git", ["config", "--local", "new-branch.pattern", config.pattern]);
+  }
+  if (config.defaultType) {
+    await execa("git", ["config", "--local", "new-branch.defaultType", config.defaultType]);
+  }
+  if (config.types && config.types.length > 0) {
+    await execa("git", ["config", "--local", "new-branch.types", JSON.stringify(config.types)]);
+  }
+  if (config.patterns && Object.keys(config.patterns).length > 0) {
+    // Write each alias as a separate key for readability
+    for (const [alias, pattern] of Object.entries(config.patterns)) {
+      await execa("git", ["config", "--local", `new-branch.patterns.${alias}`, pattern]);
+    }
+  }
 }
 
 /**

--- a/src/init/runInit.ts
+++ b/src/init/runInit.ts
@@ -1,0 +1,350 @@
+/**
+ * @module init/runInit
+ *
+ * Interactive wizard that walks the user through creating a `.newbranchrc.json`
+ * configuration file.
+ *
+ * @remarks
+ * The wizard flow:
+ * 1. Detect existing config → offer to overwrite or abort
+ * 2. Select variables to include in the pattern
+ * 3. Choose separators between variables
+ * 4. Choose transforms (for title and other text variables)
+ * 5. Show live preview
+ * 6. Optionally define branch types
+ * 7. Optionally define pattern aliases
+ * 8. Show final config → write to disk
+ */
+
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { input, select, confirm, checkbox } from "@inquirer/prompts";
+import type { ProjectConfig, BranchType } from "@/config/types.js";
+import { validateProjectConfigFinal } from "@/config/validate.js";
+import {
+  VARIABLE_OPTIONS,
+  TITLE_TRANSFORM_PRESETS,
+  DEFAULT_TYPES,
+  buildPattern,
+} from "@/init/defaults.js";
+import { renderPreview } from "@/init/preview.js";
+
+const CONFIG_FILE = ".newbranchrc.json";
+
+/**
+ * Options for {@link runInit}.
+ */
+export type InitOptions = {
+  /** Accept all defaults without prompting. */
+  yes?: boolean;
+  /** Working directory (defaults to `process.cwd()`). */
+  cwd?: string;
+};
+
+/**
+ * Runs the init wizard and writes a `.newbranchrc.json` file.
+ *
+ * @param options - Options controlling wizard behavior.
+ */
+export async function runInit(options: InitOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = resolve(cwd, CONFIG_FILE);
+
+  // Step 0: Detect existing config
+  if (existsSync(configPath)) {
+    if (options.yes) {
+      console.log(`⚠️  Overwriting existing ${CONFIG_FILE}`);
+    } else {
+      const overwrite = await confirm({
+        message: `${CONFIG_FILE} already exists. Overwrite?`,
+        default: false,
+      });
+      if (!overwrite) {
+        console.log("Aborted.");
+        return;
+      }
+    }
+  }
+
+  let config: ProjectConfig;
+
+  if (options.yes) {
+    config = buildDefaultConfig();
+  } else {
+    config = await buildInteractiveConfig();
+  }
+
+  // Validate before writing
+  validateProjectConfigFinal(config, "init wizard");
+
+  const json = JSON.stringify(config, null, 2) + "\n";
+
+  // Show final config
+  console.log("\n📄 Configuration to write:\n");
+  console.log(json);
+
+  if (!options.yes) {
+    const proceed = await confirm({
+      message: `Write to ${CONFIG_FILE}?`,
+      default: true,
+    });
+    if (!proceed) {
+      console.log("Aborted.");
+      return;
+    }
+  }
+
+  await writeFile(configPath, json, "utf-8");
+  console.log(`✅ Written to ${CONFIG_FILE}`);
+}
+
+/**
+ * Builds a config with sensible defaults (used with --yes).
+ */
+function buildDefaultConfig(): ProjectConfig {
+  return {
+    pattern: "{type}/{title:slugify}-{id}",
+    types: DEFAULT_TYPES.slice(0, 3).map((t) => ({ value: t.value, label: t.label })),
+    defaultType: "feat",
+  };
+}
+
+/**
+ * Walks the user through the interactive wizard.
+ */
+async function buildInteractiveConfig(): Promise<ProjectConfig> {
+  const config: ProjectConfig = {};
+
+  // Step 1: Select variables
+  const selectedVars = await selectVariables();
+  if (selectedVars.length === 0) {
+    console.log("No variables selected. Aborting.");
+    process.exit(0);
+  }
+
+  // Step 2: Choose separators
+  const separators = await chooseSeparators(selectedVars);
+
+  // Step 3: Choose transforms
+  const transforms = await chooseTransforms(selectedVars);
+
+  // Build pattern and show preview
+  const pattern = buildPattern(selectedVars, transforms, separators);
+  config.pattern = pattern;
+
+  const preview = renderPreview(pattern);
+  console.log(`\n🔍 Preview: ${preview}\n`);
+
+  // Step 4: Define types (optional)
+  const wantTypes = await confirm({
+    message: "Define branch types?",
+    default: true,
+  });
+
+  if (wantTypes) {
+    const { types, defaultType } = await defineTypes();
+    config.types = types;
+    if (defaultType) {
+      config.defaultType = defaultType;
+    }
+  }
+
+  // Step 5: Define aliases (optional)
+  const wantAliases = await confirm({
+    message: "Define pattern aliases for --use?",
+    default: false,
+  });
+
+  if (wantAliases) {
+    config.patterns = await defineAliases();
+  }
+
+  return config;
+}
+
+/**
+ * Prompts the user to select which variables to include.
+ */
+async function selectVariables(): Promise<string[]> {
+  const choices = VARIABLE_OPTIONS.map((v) => ({
+    name: `${v.name} — ${v.description}`,
+    value: v.name,
+    checked: v.selected,
+  }));
+
+  return checkbox({
+    message: "Which variables do you want in your branch name?",
+    choices,
+  });
+}
+
+/**
+ * Prompts for separators between variables.
+ */
+async function chooseSeparators(variables: string[]): Promise<string[]> {
+  if (variables.length <= 1) return [];
+
+  const separators: string[] = [];
+  for (let i = 0; i < variables.length - 1; i++) {
+    const defaultSep = i === 0 && variables[0] === "type" ? "/" : "-";
+    const sep = await select({
+      message: `Separator between {${variables[i]}} and {${variables[i + 1]}}:`,
+      choices: [
+        { name: "/ (slash)", value: "/" },
+        { name: "- (dash)", value: "-" },
+        { name: "_ (underscore)", value: "_" },
+        { name: ". (dot)", value: "." },
+      ],
+      default: defaultSep,
+    });
+    separators.push(sep);
+  }
+
+  return separators;
+}
+
+/**
+ * Prompts for transforms to apply to text variables.
+ */
+async function chooseTransforms(variables: string[]): Promise<Record<string, string>> {
+  const transforms: Record<string, string> = {};
+
+  // Only offer transforms for text-content variables
+  const textVars = variables.filter(
+    (v) => !["type", "id", "year", "month", "day", "date", "dateCompact", "shortSha"].includes(v),
+  );
+
+  for (const v of textVars) {
+    const preset = await select({
+      message: `Apply transforms to {${v}}?`,
+      choices: TITLE_TRANSFORM_PRESETS.map((p) => ({
+        name: p.label,
+        value: p.chain,
+      })),
+      default: "slugify",
+    });
+
+    if (preset.includes("max")) {
+      const maxVal = await input({
+        message: `Max length for {${v}}? (characters)`,
+        default: "30",
+        validate: (val) => {
+          const n = Number(val);
+          return n > 0 && Number.isInteger(n) ? true : "Enter a positive integer";
+        },
+      });
+      transforms[v] = preset.replace("max:30", `max:${maxVal}`);
+    } else if (preset) {
+      transforms[v] = preset;
+    }
+  }
+
+  return transforms;
+}
+
+/**
+ * Prompts the user to define branch types.
+ */
+async function defineTypes(): Promise<{ types: BranchType[]; defaultType?: string }> {
+  const useDefaults = await confirm({
+    message: `Use common defaults (${DEFAULT_TYPES.slice(0, 3)
+      .map((t) => t.value)
+      .join(", ")})?`,
+    default: true,
+  });
+
+  let types: BranchType[];
+
+  if (useDefaults) {
+    types = DEFAULT_TYPES.slice(0, 3).map((t) => ({ value: t.value, label: t.label }));
+
+    const addMore = await confirm({
+      message: "Add more types?",
+      default: false,
+    });
+
+    if (addMore) {
+      const extras = await addCustomTypes();
+      types = [...types, ...extras];
+    }
+  } else {
+    types = await addCustomTypes();
+    if (types.length === 0) {
+      return { types: [] };
+    }
+  }
+
+  // Default type
+  const defaultType = await select({
+    message: "Set a default type?",
+    choices: [
+      ...types.map((t) => ({ name: `${t.value} (${t.label})`, value: t.value })),
+      { name: "(none)", value: "__none__" },
+    ],
+    default: types[0]?.value,
+  });
+
+  return {
+    types,
+    defaultType: defaultType === "__none__" ? undefined : defaultType,
+  };
+}
+
+/**
+ * Interactive loop to add custom branch types.
+ */
+async function addCustomTypes(): Promise<BranchType[]> {
+  const types: BranchType[] = [];
+
+  while (true) {
+    const value = await input({
+      message: "Type value (e.g., feat) — leave blank to finish:",
+    });
+
+    if (!value.trim()) break;
+
+    const label = await input({
+      message: `Label for "${value.trim()}":`,
+      default: value.trim().charAt(0).toUpperCase() + value.trim().slice(1),
+    });
+
+    types.push({ value: value.trim(), label: label.trim() });
+  }
+
+  return types;
+}
+
+/**
+ * Interactive loop to add pattern aliases.
+ */
+async function defineAliases(): Promise<Record<string, string>> {
+  const patterns: Record<string, string> = {};
+
+  while (true) {
+    const name = await input({
+      message: "Alias name (e.g., hotfix) — leave blank to finish:",
+    });
+
+    if (!name.trim()) break;
+
+    const pattern = await input({
+      message: `Pattern for "${name.trim()}":`,
+      validate: (val) => (val.trim().length > 0 ? true : "Pattern cannot be empty"),
+    });
+
+    patterns[name.trim()] = pattern.trim();
+
+    const preview = renderPreview(pattern.trim());
+    console.log(`   🔍 Preview: ${preview}`);
+
+    const addMore = await confirm({
+      message: "Add another alias?",
+      default: false,
+    });
+
+    if (!addMore) break;
+  }
+
+  return patterns;
+}


### PR DESCRIPTION
## Summary

Adds `new-branch init` — an interactive wizard that bootstraps a `new-branch` configuration with live preview.

Closes #23

## What it does

Running `new-branch init` walks the user through:

1. **Config target** — choose where to save (`.newbranchrc.json`, `package.json`, or `git config`)
2. **Variable selection** — checkbox of available pattern variables (`type`, `title`, `id`, `date`, etc.)
3. **Separators** — pick `/`, `-`, `_`, or `.` between each variable pair
4. **Transforms** — choose from presets (`slugify`, `kebab`, `snake`, etc.) for text variables
5. **Live preview** — shows a realistic branch name using mock values at each step
6. **Branch types** — optionally define allowed types with defaults (feat, fix, chore)
7. **Pattern aliases** — optionally define named patterns for `--use`
8. **Write config** — preview final JSON and confirm before writing

### Non-interactive mode

```bash
new-branch init --yes   # writes sensible defaults to .newbranchrc.json
```

## New files

| File | Purpose |
|------|---------|
| `src/init/defaults.ts` | `VARIABLE_OPTIONS`, `TITLE_TRANSFORM_PRESETS`, `DEFAULT_TYPES`, `buildPattern()` |
| `src/init/preview.ts` | `renderPreview()` with deterministic `MOCK_VALUES` |
| `src/init/runInit.ts` | Main wizard orchestrator with `writeConfig()` supporting 3 targets |
| `src/init/defaults.test.ts` | Tests for defaults and `buildPattern()` |
| `src/init/preview.test.ts` | Tests for `renderPreview()` with valid/invalid patterns |
| `src/init/runInit.test.ts` | Tests for wizard flow, config targets, overwrite detection |
| `docs/guide/init.md` | Full documentation page for the init wizard |

## Changes to existing files

- **`src/cli.ts`** — detect `init` subcommand before positional stripping, pass `--yes`/`-y`
- **`src/cli.test.ts`** — tests for init subcommand delegation
- **`README.md`** — add init to Quick Start, Features, and Documentation table
- **`docs/`** — updated getting-started, cli-options, configuration, index, sidebar config

## Test results

- **300 tests passing** across 44 files
- Build passes with no TypeScript errors
- Docs build passes
